### PR TITLE
multipage: use get() as it's safer than bracket indexing

### DIFF
--- a/multipage.py
+++ b/multipage.py
@@ -35,8 +35,8 @@ class MultiPage:
         page = st.sidebar.selectbox(
             'App Navigation', 
             self.pages, 
-            format_func=lambda page: page['title']
+            format_func=lambda page: page.get('title', "")
         )
 
         # run the app function 
-        page['function']()
+        page.get('function')()


### PR DESCRIPTION
The use of `get()` is considered to be safer and better than bracket indexing.